### PR TITLE
RFC 0003: create a separate libp2p org

### DIFF
--- a/rfcs/0003-spin-off-libp2p-org.md
+++ b/rfcs/0003-spin-off-libp2p-org.md
@@ -1,0 +1,44 @@
+- Feature Name: ispin-off-libp2p-org
+- Start Date: 2018-02-09
+- RFC PR: (leave this empty)
+- IPFS Issue: (leave this empty)
+
+# Summary
+[summary]: #summary
+
+Create a separate organization to govern libp2p, with its own Roadmaps, RFCs and working groups.  While the development teams working on IPFS and libp2p will continue to overlap strongly for a long time, this separation will allow libp2p to evolve along a trajectory that acknowledges all of its users without forcing those users to work through the IPFS org even if they aren't using IPFS.
+
+# Motivation
+[motivation]: #motivation
+
+Why are we doing this? What use cases does it support? What is the expected outcome?
+
+Though the code base of libp2p initially evolved within IPFS, libp2p has its own distinct set of users, use cases, and adoption timelines. Decoupling the two protocols while maintaining tight coordination of the development roadmaps is a healthy move for both projects. It allows libp2p to accumulate its own set of adopters and contributors -- most of whom desperately need libp2p but do not need IPFS.
+
+# Guide-level explanation
+[guide-level-explanation]: #guide-level-explanation
+
+TODO
+
+# Reference-level explanation
+[reference-level-explanation]: #reference-level-explanation
+
+TODO
+
+# Drawbacks
+[drawbacks]: #drawbacks
+
+Why should we *not* do this?
+
+# Rationale and alternatives
+[alternatives]: #alternatives
+
+- Why is this design the best in the space of possible designs?
+- What other designs have been considered and what is the rationale for not choosing them?
+- What is the impact of not doing this?
+
+# Unresolved questions
+[unresolved]: #unresolved-questions
+
+Resolve before merging:
+- Should RFCs be tracked separately, or should both orgs share a single RFCs repository?


### PR DESCRIPTION
Proposes creating a separate libp2p org to steward that code base and engage with its user base, which is distinct from the IPFS user base.